### PR TITLE
update (ExpandedNodeId)String() method to create OPC UA standard compliant string representations; add tests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: "0 2 * * *" # every day at 2 AM UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 180
+          days-before-close: 7
+          stale-issue-message: "This issue has been automatically marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs."
+          close-issue-message: "Closing due to inactivity."
+          stale-pr-message: "This pull request has been marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs."
+          close-pr-message: "Closing this PR due to inactivity."
+          exempt-issue-labels: "pinned,security"
+          exempt-pr-labels: "pinned,security"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.7.3 (7 Apr 2025)
+
+### v0.7.2 changes
+
+* server: Prevent panic on context cancellation (#785)
+* Add Fallback to set session.AuthPolicyURI (#706, #779)
+* client: send events con connection changes (#741, #767)
+* uasc: Set conn write deadline for sendAsyncWithTimeout (#771)
+
+### v0.7.3 changes
+
+* uasc: Removed hardcoded SecurityMode in SecureChannel reacDhunk method (#780)
+* server: obay access levels in the server (#778)
+
+## ~v0.7.2~ (7 Apr 2025)
+
+### Retracted since I've tagged the wrong branch
+### Only the tag and the CHANGELOG are on the wrong branch. The code is on main.
+
 ## v0.7.1 (27 Feb 2025)
 
 * client: use nil-checked secure channel (#775)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ go run examples/crypto/*.go -endpoint opc.tcp://localhost:4840 -cert path/to/cer
 # checkout examples/ for more examples...
 ```
 
-## List of Breaking Changes
+## List of Breaking Changes and noteworthy issues
 
+* v0.7.2: Tagged the wrong branch, deleted the tag, retracted the version, moved changes to v0.7.3 and v0.7.4 instead
 * `v0.7.0: The node attributes for the server now use ua.DataValue instead of ua.Variant (#766)`
 * `v0.6.0`: The `SelectEndpoint` function in the client now returns an error (#753)
 * `v0.5.1`: The `NewClient` function returns an error

--- a/examples/server/node_server/server.go
+++ b/examples/server/node_server/server.go
@@ -212,8 +212,8 @@ func main() {
 	var4 := server.NewNode(
 		ua.NewNumericNodeID(nodeNS.ID(), 3321), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
-			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
-			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
 			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("testBrowseName")),
 			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
 		},
@@ -226,8 +226,8 @@ func main() {
 	var5 := server.NewNode(
 		ua.NewNumericNodeID(nodeNS.ID(), 222), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
-			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
-			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
 			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
 			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
 		},

--- a/examples/server/node_server/server.go
+++ b/examples/server/node_server/server.go
@@ -210,11 +210,11 @@ func main() {
 	nns_obj.AddRef(var3, id.HasComponent, true)
 
 	var4 := server.NewNode(
-		ua.NewNumericNodeID(nodeNS.ID(), 3321), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		ua.NewNumericNodeID(nodeNS.ID(), 100), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
 			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
 			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
-			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("testBrowseName")),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadWriteVariable")),
 			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
 		},
 		nil,
@@ -224,7 +224,7 @@ func main() {
 	nns_obj.AddRef(var4, id.HasComponent, true)
 
 	var5 := server.NewNode(
-		ua.NewNumericNodeID(nodeNS.ID(), 222), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		ua.NewNumericNodeID(nodeNS.ID(), 101), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
 			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
 			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
@@ -236,6 +236,20 @@ func main() {
 	)
 	nodeNS.AddNode(var5)
 	nns_obj.AddRef(var5, id.HasComponent, true)
+
+	var6 := server.NewNode(
+		ua.NewNumericNodeID(nodeNS.ID(), 102), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("NoAccessVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(9.87) },
+	)
+	nodeNS.AddNode(var6)
+	nns_obj.AddRef(var6, id.HasComponent, true)
 
 	// simulate a background process updating the data in the namespace.
 	go func() {

--- a/examples/server/node_server/server.go
+++ b/examples/server/node_server/server.go
@@ -191,7 +191,7 @@ func main() {
 	// your variable node's value can also return a ua.Variant from a function if you want to update the value dynamically
 	// here we are just incrementing a counter every time the value is read.
 	var2Value := int32(0)
-	var2 := nodeNS.AddNewVariableStringNode("TestVar2", func() *ua.Variant { var2Value++; return ua.MustVariant(var2Value) })
+	var2 := nodeNS.AddNewVariableStringNode("TestVar2", func() *ua.DataValue { var2Value++; return server.DataValueFromValue(var2Value) })
 	nns_obj.AddRef(var2, id.HasComponent, true)
 
 	// Now we'll add a node from scratch.  This is a more manual way to add nodes to the server and gives you full
@@ -208,6 +208,34 @@ func main() {
 	)
 	nodeNS.AddNode(var3)
 	nns_obj.AddRef(var3, id.HasComponent, true)
+
+	var4 := server.NewNode(
+		ua.NewNumericNodeID(nodeNS.ID(), 3321), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("testBrowseName")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(12.34) },
+	)
+	nodeNS.AddNode(var4)
+	nns_obj.AddRef(var4, id.HasComponent, true)
+
+	var5 := server.NewNode(
+		ua.NewNumericNodeID(nodeNS.ID(), 222), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(9.87) },
+	)
+	nodeNS.AddNode(var5)
+	nns_obj.AddRef(var5, id.HasComponent, true)
 
 	// simulate a background process updating the data in the namespace.
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 retract (
+	v0.7.2 // tagged the wrong branch
 	v0.2.5 // https://github.com/gopcua/opcua/issues/538
 	v0.2.4 // https://github.com/gopcua/opcua/issues/538
 )

--- a/server/monitored_item_service.go
+++ b/server/monitored_item_service.go
@@ -58,7 +58,7 @@ func (s *MonitoredItemService) DeleteMonitoredItem(id uint32) {
 			continue
 		}
 		if n.ID == id {
-			slices.Delete(s.Nodes[nodeid], i, i+1)
+			s.Nodes[nodeid] = slices.Delete(s.Nodes[nodeid], i, i+1)
 		}
 	}
 	//slices.DeleteFunc(s.Nodes[nodeid], func(i *MonitoredItem) bool { return i.ID == item.ID })
@@ -72,7 +72,7 @@ func (s *MonitoredItemService) DeleteMonitoredItem(id uint32) {
 			continue
 		}
 		if n.ID == id {
-			slices.Delete(s.Subs[item.Sub.ID], i, i+1)
+			s.Subs[item.Sub.ID] = slices.Delete(s.Subs[item.Sub.ID], i, i+1)
 		}
 	}
 	//slices.DeleteFunc(s.Subs[item.Sub.ID], func(i *MonitoredItem) bool { return i.ID == item.ID })

--- a/server/namespace_node.go
+++ b/server/namespace_node.go
@@ -252,10 +252,66 @@ func (as *NodeNameSpace) SetAttribute(id *ua.NodeID, attr ua.AttributeID, val *u
 	}
 
 	access, err := n.Attribute(ua.AttributeIDUserAccessLevel)
-	if err == nil {
-		x := access.Value.Value.Value()
-		_ = x
-		return ua.StatusBadUserAccessDenied
+	if err == nil { // if we have an access level, we need to check it.
+		x := 0
+		switch val := access.Value.Value.Value().(type) {
+		case int8:
+			x = int(val)
+		case int:
+			x = int(val)
+		case int32:
+			x = int(val)
+		case int64:
+			x = int(val)
+		case uint32:
+			x = int(val)
+		case uint64:
+			x = int(val)
+		case uint:
+			x = int(val)
+		case uint16:
+			x = int(val)
+		case uint8:
+			x = int(val)
+		default:
+			return ua.StatusBadUserAccessDenied // if we can't convert it, we can't use it.
+		}
+
+		requirement := int(ua.AccessLevelExTypeCurrentWrite)
+		if x&requirement == 0 {
+			return ua.StatusBadUserAccessDenied
+		}
+	}
+	access, err = n.Attribute(ua.AttributeIDAccessLevel)
+	if err == nil { // if we have an access level, we need to check it.
+		x := 0
+		switch val := access.Value.Value.Value().(type) {
+		case int8:
+			x = int(val)
+		case int:
+			x = int(val)
+		case int32:
+			x = int(val)
+		case int64:
+			x = int(val)
+		case uint32:
+			x = int(val)
+		case uint64:
+			x = int(val)
+		case uint:
+			x = int(val)
+		case uint16:
+			x = int(val)
+		case uint8:
+			x = int(val)
+		default:
+			return ua.StatusBadUserAccessDenied // if we can't convert it, we can't use it.
+		}
+
+		requirement := int(ua.AccessLevelExTypeCurrentWrite)
+		if x&requirement == 0 {
+			return ua.StatusBadUserAccessDenied
+		}
 	}
 
 	err = n.SetAttribute(attr, val)

--- a/server/node.go
+++ b/server/node.go
@@ -28,6 +28,26 @@ func NewAttrValue(v *ua.DataValue) *AttrValue {
 }
 
 func DataValueFromValue(val any) *ua.DataValue {
+	// if we already have a data value, just return it.
+	switch v := val.(type) {
+	case *ua.DataValue:
+		return v
+	case ua.DataValue:
+		return &v
+	case ua.Variant:
+		return &ua.DataValue{
+			EncodingMask:    ua.DataValueValue,
+			Value:           &v,
+			SourceTimestamp: time.Now(),
+		}
+	case *ua.Variant:
+		return &ua.DataValue{
+			EncodingMask:    ua.DataValueValue,
+			Value:           v,
+			SourceTimestamp: time.Now(),
+		}
+
+	}
 
 	v := ua.MustVariant(val)
 	return &ua.DataValue{

--- a/server/node.go
+++ b/server/node.go
@@ -46,6 +46,12 @@ func DataValueFromValue(val any) *ua.DataValue {
 			Value:           v,
 			SourceTimestamp: time.Now(),
 		}
+	case int:
+		return &ua.DataValue{
+			EncodingMask:    ua.DataValueValue,
+			Value:           ua.MustVariant(int32(v)),
+			SourceTimestamp: time.Now(),
+		}
 
 	}
 

--- a/server/node.go
+++ b/server/node.go
@@ -99,6 +99,10 @@ func NewVariableNode(nodeID *ua.NodeID, name string, value any) *Node {
 				return DataValueFromValue(value)
 			},
 		)
+		dvFunc, ok := value.(ValueFunc)
+		if ok {
+			n.val = dvFunc
+		}
 		return n
 	}
 	typedef := ua.NewNumericExpandedNodeID(0, id.VariableNode)
@@ -154,7 +158,11 @@ func (n *Node) Attribute(id ua.AttributeID) (*AttrValue, error) {
 	switch {
 	case id == ua.AttributeIDValue:
 		if n.val != nil {
-			return NewAttrValue(n.val()), nil
+			val := n.val()
+			if val == nil {
+				return nil, ua.StatusBadAttributeIDInvalid
+			}
+			return NewAttrValue(val), nil
 		}
 		return nil, ua.StatusBadAttributeIDInvalid
 	case n.attr == nil:

--- a/server/node.go
+++ b/server/node.go
@@ -25,6 +25,7 @@ type AttrValue struct {
 
 func NewAttrValue(v *ua.DataValue) *AttrValue {
 	return &AttrValue{Value: v}
+
 }
 
 func DataValueFromValue(val any) *ua.DataValue {

--- a/server/node.go
+++ b/server/node.go
@@ -325,3 +325,39 @@ func (n *Node) AddRef(o *Node, rt RefType, forward bool) {
 	}
 	n.refs = append(n.refs, &ref)
 }
+
+// Access returns true if the node has the access level requested.
+// It checks both the UserAccessLevel and AccessLevel attributes.
+// If neither are present, it assumes global access and returns true.
+//
+// I'm not sure what the best way to implement "user" specific access levels
+// is presently.  Will need functioning user authentication first, and then a way to
+// pass it into the nodes user access attribute so it can be checked properly.
+func (n Node) Access(flag ua.AccessLevelType) bool {
+
+	access, err := n.Attribute(ua.AttributeIDUserAccessLevel)
+	if err == nil { // if we have a user access level, we need to check it.
+		val0 := access.Value.Value.Value()
+		val, ok := val0.(uint8)
+		if !ok {
+			return false
+		}
+		if val&uint8(flag) == 0 {
+			return false
+		}
+	}
+	access, err = n.Attribute(ua.AttributeIDAccessLevel)
+	if err == nil { // if we have an access level, we need to check it.
+		val0 := access.Value.Value.Value()
+		val, ok := val0.(uint8)
+		if !ok {
+			return false
+		}
+
+		if val&uint8(flag) == 0 {
+			return false
+		}
+	}
+	return true
+
+}

--- a/server/nodeset2_import.go
+++ b/server/nodeset2_import.go
@@ -17,7 +17,7 @@ func (srv *Server) ImportNodeSet(nodes *schema.UANodeSet) error {
 	if err != nil {
 		return fmt.Errorf("problem creating nodes: %w", err)
 	}
-	srv.refsImportNodeSet(nodes)
+	err = srv.refsImportNodeSet(nodes)
 	if err != nil {
 		return fmt.Errorf("problem creating references: %w", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -144,6 +144,8 @@ func New(opts ...Option) *Server {
 	//s.namespaces[0].AddNode(n)
 	//}
 
+	// this nodeset is pre-compiled into the binary and contains a known set of nodes
+	// so it should *always* work ok.
 	var nodes schema.UANodeSet
 	xml.Unmarshal(schema.OpcUaNodeSet2, &nodes)
 

--- a/server/session_service.go
+++ b/server/session_service.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/rand"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/gopcua/opcua/ua"
@@ -59,9 +60,11 @@ func (s *SessionService) CreateSession(sc *uasc.SecureChannel, r ua.Request, req
 	}
 
 	matching_endpoints := make([]*ua.EndpointDescription, 0)
+	reqTrimmedURL, _ := strings.CutSuffix(req.EndpointURL, "/")
 	for i := range s.srv.endpoints {
 		ep := s.srv.endpoints[i]
-		if ep.EndpointURL == req.EndpointURL {
+		epTrimmedURL, _ := strings.CutSuffix(ep.EndpointURL, "/")
+		if epTrimmedURL == reqTrimmedURL {
 			matching_endpoints = append(matching_endpoints, ep)
 		}
 	}

--- a/server/view_service.go
+++ b/server/view_service.go
@@ -110,7 +110,7 @@ func suitableRefType(srv *Server, ref1, ref2 *ua.NodeID, subtypes bool) bool {
 	oktypes := getSubRefs(srv, ref1)
 	if !subtypes && slices.ContainsFunc(oktypes, hasSubtypeFn) {
 		for n := slices.IndexFunc(oktypes, hasSubtypeFn); n > 0; {
-			slices.Delete(oktypes, n, n+1)
+			oktypes = slices.Delete(oktypes, n, n+1)
 		}
 	}
 	return slices.ContainsFunc(oktypes, hasRef2Fn)

--- a/tests/go/server.go
+++ b/tests/go/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/server"
+	"github.com/gopcua/opcua/server/attrs"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -67,6 +68,60 @@ func startServer() *server.Server {
 	nns_obj.AddRef(n, id.HasComponent, true)
 	n = nodeNS.AddNewVariableStringNode("rw_int32", int32(5))
 	nns_obj.AddRef(n, id.HasComponent, true)
+
+	var3 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "NoPermVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDBrowseName: server.DataValueFromValue(attrs.BrowseName("NoPermVariable")),
+			ua.AttributeIDNodeClass:  server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(int32(742)) },
+	)
+	nodeNS.AddNode(var3)
+	nns_obj.AddRef(var3, id.HasComponent, true)
+
+	var4 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "ReadWriteVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadWriteVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(12.34) },
+	)
+	nodeNS.AddNode(var4)
+	nns_obj.AddRef(var4, id.HasComponent, true)
+
+	var5 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "ReadOnlyVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(9.87) },
+	)
+	nodeNS.AddNode(var5)
+	nns_obj.AddRef(var5, id.HasComponent, true)
+
+	var6 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "NoAccessVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("NoAccessVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(55.43) },
+	)
+	nodeNS.AddNode(var6)
+	nns_obj.AddRef(var6, id.HasComponent, true)
 
 	// Create a new node namespace.  You can add namespaces before or after starting the server.
 	gopcuaNS := server.NewNodeNameSpace(s, "http://gopcua.com/")

--- a/tests/python/method_server.py
+++ b/tests/python/method_server.py
@@ -9,14 +9,13 @@ class Complex(uatypes.FrozenClass):
         ('j', 'Int64'),
     ]
 
-    def __init__(self):
-        self.i = 0
-        self.j = 0
+    def __init__(self, i=0, j=0):
+        self.i = i
+        self.j = j
         self._freeze = True
 
     def __str__(self):
-        return 'Complex(' + 'i:' + str(self.i) + ', ' + \
-               'j:' + str(self.j) + ')'
+        return f'Complex(i:{self.i}, j:{self.j})'
 
     __repr__ = __str__
 

--- a/tests/python/method_server.py
+++ b/tests/python/method_server.py
@@ -36,6 +36,10 @@ def sum_of_squares(parent, variant):
     ret = v.i*v.i + v.j*v.j
     return [ua.Variant(ret, ua.VariantType.Int64)]
 
+def issue_768(parent):
+    print("no_args method call returns []ua.ExtensionObject")
+    return [ua.Variant([Complex(1,2), Complex(3,4)])]
+
 if __name__ == "__main__":
     server = Server()
     server.set_endpoint("opc.tcp://0.0.0.0:4840/")
@@ -46,5 +50,6 @@ if __name__ == "__main__":
     fnEven = main.add_method(ua.NodeId("even", ns), "even", even, [ua.VariantType.Int64], [ua.VariantType.Boolean])
     fnSquare = main.add_method(ua.NodeId("square", ns), "square", square, [ua.VariantType.Int64], [ua.VariantType.Int64])
     fnSumOfSquare = main.add_method(ua.NodeId("sumOfSquare", ns), "sumOfSquare", sum_of_squares, [ua.VariantType.ExtensionObject], [ua.VariantType.Int64])
+    fnNoArgs = main.add_method(ua.NodeId("issue768", ns), "issue768", issue_768, [])
 
     server.start()

--- a/tests/python/method_server.py
+++ b/tests/python/method_server.py
@@ -33,7 +33,7 @@ def square(parent, variant):
 
 def sum_of_squares(parent, variant):
     v = variant.Value # type is extension object "Complex"
-    print("sum_of_square methos call with parameter: ", v)
+    print("sum_of_square method call with parameter: ", v)
     ret = v.i*v.i + v.j*v.j
     return [ua.Variant(ret, ua.VariantType.Int64)]
 

--- a/tests/python/method_test.go
+++ b/tests/python/method_test.go
@@ -19,10 +19,12 @@ func TestCallMethod(t *testing.T) {
 	ua.RegisterExtensionObject(ua.NewStringNodeID(2, "ComplexType"), new(Complex))
 
 	tests := []struct {
-		req *ua.CallMethodRequest
-		out []*ua.Variant
+		name string
+		req  *ua.CallMethodRequest
+		resp *ua.CallMethodResult
 	}{
 		{
+			name: "even",
 			req: &ua.CallMethodRequest{
 				ObjectID: ua.NewStringNodeID(2, "main"),
 				MethodID: ua.NewStringNodeID(2, "even"),
@@ -30,9 +32,15 @@ func TestCallMethod(t *testing.T) {
 					ua.MustVariant(int64(12)),
 				},
 			},
-			out: []*ua.Variant{ua.MustVariant(true)},
+			resp: &ua.CallMethodResult{
+				StatusCode:                   ua.StatusOK,
+				InputArgumentResults:         []ua.StatusCode{ua.StatusOK},
+				InputArgumentDiagnosticInfos: []*ua.DiagnosticInfo{},
+				OutputArguments:              []*ua.Variant{ua.MustVariant(true)},
+			},
 		},
 		{
+			name: "square",
 			req: &ua.CallMethodRequest{
 				ObjectID: ua.NewStringNodeID(2, "main"),
 				MethodID: ua.NewStringNodeID(2, "square"),
@@ -40,9 +48,15 @@ func TestCallMethod(t *testing.T) {
 					ua.MustVariant(int64(3)),
 				},
 			},
-			out: []*ua.Variant{ua.MustVariant(int64(9))},
+			resp: &ua.CallMethodResult{
+				StatusCode:                   ua.StatusOK,
+				InputArgumentResults:         []ua.StatusCode{ua.StatusOK},
+				InputArgumentDiagnosticInfos: []*ua.DiagnosticInfo{},
+				OutputArguments:              []*ua.Variant{ua.MustVariant(int64(9))},
+			},
 		},
 		{
+			name: "sumOfSquare",
 			req: &ua.CallMethodRequest{
 				ObjectID: ua.NewStringNodeID(2, "main"),
 				MethodID: ua.NewStringNodeID(2, "sumOfSquare"),
@@ -50,7 +64,13 @@ func TestCallMethod(t *testing.T) {
 					ua.MustVariant(ua.NewExtensionObject(&Complex{3, 8})),
 				},
 			},
-			out: []*ua.Variant{ua.MustVariant(int64(9 + 64))},
+			resp: &ua.CallMethodResult{
+				StatusCode:                   ua.StatusOK,
+				InputArgumentResults:         []ua.StatusCode{ua.StatusOK},
+				InputArgumentDiagnosticInfos: []*ua.DiagnosticInfo{},
+				OutputArguments:              []*ua.Variant{ua.MustVariant(int64(9 + 64))},
+			},
+		},
 		},
 	}
 
@@ -67,11 +87,10 @@ func TestCallMethod(t *testing.T) {
 	defer c.Close(ctx)
 
 	for _, tt := range tests {
-		t.Run(tt.req.ObjectID.String(), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			resp, err := c.Call(ctx, tt.req)
 			require.NoError(t, err, "Call failed")
-			require.Equal(t, ua.StatusOK, resp.StatusCode, "StatusCode not equal")
-			require.Equal(t, tt.out, resp.OutputArguments, "OuptutArgs not equal")
+			require.Equal(t, tt.resp, resp, "Response not equal")
 		})
 	}
 }

--- a/tests/python/method_test.go
+++ b/tests/python/method_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Complex struct {
-	i, j int64
+	I, J int64
 }
 
 func TestCallMethod(t *testing.T) {
@@ -71,6 +71,24 @@ func TestCallMethod(t *testing.T) {
 				OutputArguments:              []*ua.Variant{ua.MustVariant(int64(9 + 64))},
 			},
 		},
+		{
+			name: "issue768_array_of_extobjs",
+			req: &ua.CallMethodRequest{
+				ObjectID:       ua.NewStringNodeID(2, "main"),
+				MethodID:       ua.NewStringNodeID(2, "issue768"),
+				InputArguments: []*ua.Variant{},
+			},
+			resp: &ua.CallMethodResult{
+				StatusCode:                   ua.StatusOK,
+				InputArgumentResults:         []ua.StatusCode{},
+				InputArgumentDiagnosticInfos: []*ua.DiagnosticInfo{},
+				OutputArguments: []*ua.Variant{ua.MustVariant(
+					[]*ua.ExtensionObject{
+						ua.NewExtensionObject(&Complex{1, 2}),
+						ua.NewExtensionObject(&Complex{3, 4}),
+					},
+				)},
+			},
 		},
 	}
 

--- a/ua/expanded_node_id_test.go
+++ b/ua/expanded_node_id_test.go
@@ -106,3 +106,29 @@ func TestParseExpandedNodeID(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandedNodeID_String(t *testing.T) {
+	cases := []struct {
+		name string
+		n    ExpandedNodeID
+		sRep string
+	}{
+		{name: "svr=1;nsu=urn:abc:123;i=3344", n: ExpandedNodeID{ServerIndex: 1, NamespaceURI: "urn:abc:123", NodeID: NewNumericNodeID(1, 3344)}, sRep: "svr=1;nsu=urn:abc:123;i=3344"},
+		{name: "nsu=urn:abc:123;i=3344, ns=1", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "urn:abc:123", NodeID: NewNumericNodeID(1, 3344)}, sRep: "nsu=urn:abc:123;i=3344"},
+		{name: "nsu=urn:abc:123;i=3344, ns=0", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "urn:abc:123", NodeID: NewNumericNodeID(0, 3344)}, sRep: "nsu=urn:abc:123;i=3344"},
+		{name: "ns=1;i=3344", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewNumericNodeID(1, 3344)}, sRep: "ns=1;i=3344"},
+		{name: "i=4, TwoByteNodeId", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewTwoByteNodeID(uint8(4))}, sRep: "i=4"},
+		{name: "ns=2;i=5432, FourByteNodeId", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewFourByteNodeID(2, 5432)}, sRep: "ns=2;i=5432"},
+		{name: "i=3344", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewNumericNodeID(0, 3344)}, sRep: "i=3344"},
+		{name: "guid identifier", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewGUIDNodeID(3, NewGUID("09087e75-8e5e-499b-954f-f2a9603db28a").String())}, sRep: "ns=3;g=09087E75-8E5E-499B-954F-F2A9603DB28A"},
+		{name: "string identifier", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewStringNodeID(5, "mystring")}, sRep: "ns=5;s=mystring"},
+		{name: "opaque identifier", n: ExpandedNodeID{ServerIndex: 0, NamespaceURI: "", NodeID: NewByteStringNodeID(5, []byte{1, 2, 3, 4})}, sRep: "ns=5;b=AQIDBA=="},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			str := c.n.String()
+			require.Equal(t, c.sRep, str)
+		})
+	}
+}

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -481,6 +481,11 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 			s.cfg.RemoteCertificate = m.AsymmetricSecurityHeader.SenderCertificate
 			debug.Printf("uasc %d: setting securityPolicy to %s", s.c.ID(), m.SecurityPolicyURI)
 
+			if s.cfg.SecurityMode != ua.MessageSecurityModeSignAndEncrypt &&
+				s.cfg.SecurityMode != ua.MessageSecurityModeInvalid {
+				s.cfg.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
+			}
+
 			remoteCert, err := x509.ParseCertificate(s.cfg.RemoteCertificate)
 			if err != nil {
 				return nil, err

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -481,11 +481,6 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 			s.cfg.RemoteCertificate = m.AsymmetricSecurityHeader.SenderCertificate
 			debug.Printf("uasc %d: setting securityPolicy to %s", s.c.ID(), m.SecurityPolicyURI)
 
-			// TODO: where does this need to actually be set?  It should be independent of the securitypolicy
-			// but here I'm just assuming it is sign and encrypt when we have anything other than None
-			// The problem is we need to know whether the message has to be decrypted before we can look at the
-			// security mode field in the open request to see if it is encrypted!
-			s.cfg.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
 			remoteCert, err := x509.ParseCertificate(s.cfg.RemoteCertificate)
 			if err != nil {
 				return nil, err

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -319,7 +319,12 @@ func TestNewSecureChannel(t *testing.T) {
 	t.Run("uri not none, mode none", func(t *testing.T) {
 		cfg := &Config{SecurityPolicyURI: ua.SecurityPolicyURIBasic256, SecurityMode: ua.MessageSecurityModeNone}
 		_, err := NewSecureChannel("", &uacp.Conn{}, cfg, make(chan error))
-		require.ErrorContains(t, err, "Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' cannot be used with 'MessageSecurityModeNone'")
+		require.ErrorContains(t, err, "invalid channel config: Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' can only be used with 'MessageSecurityModeSign' or 'MessageSecurityModeSignAndEncrypt'")
+	})
+	t.Run("uri not none, security policy not none, mode invalid", func(t *testing.T) {
+		cfg := &Config{SecurityPolicyURI: ua.SecurityPolicyURIBasic256, SecurityMode: ua.MessageSecurityModeInvalid}
+		_, err := NewSecureChannel("", &uacp.Conn{}, cfg, make(chan error))
+		require.ErrorContains(t, err, "invalid channel config: Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' can only be used with 'MessageSecurityModeSign' or 'MessageSecurityModeSignAndEncrypt'")
 	})
 	t.Run("uri not none, local key missing", func(t *testing.T) {
 		cfg := &Config{SecurityPolicyURI: ua.SecurityPolicyURIBasic256, SecurityMode: ua.MessageSecurityModeSign}


### PR DESCRIPTION

The implementation consciously does access the ExpandedNodeId structure components directly and not using existing accessor methods. 
For full compliance with the OPC UA standard an eventually present namespaceUri must URL encode special characters. This encoding is assumed to happen during the creation of an ExpandedNodeId